### PR TITLE
Fix calls to `timer_start`

### DIFF
--- a/autoload/intero/loc.vim
+++ b/autoload/intero/loc.vim
@@ -6,7 +6,7 @@
 
 function! intero#loc#go_to_def()
     call intero#repl#send(intero#util#make_command(':loc-at'))
-    call timer_start(100, 's:do_the_hop', { 'repeat': 1 })
+    call timer_start(100, function('s:do_the_hop'), { 'repeat': 1 })
 endfunction
 
 function! intero#loc#get_identifier_information()
@@ -30,7 +30,7 @@ endfunction
 " Private:
 """"""""""
 
-function! s:do_the_hop()
+function! s:do_the_hop(timer)
     let l:response = join(intero#repl#get_last_response(), "\n")
     let l:split = split(l:response, ':')
     if len(l:split) != 2

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -82,7 +82,11 @@ function! s:term_buffer(job_id, data, event)
     " let g:intero_last_response = intero#repl#get_last_response()
 endfunction
 
-function! s:on_response()
+function! s:on_response(timer)
+    if !exists('g:intero_buffer_id')
+      return
+    endif
+
     let l:mode = mode()
 
     if ! (exists('g:intero_should_echo') && g:intero_should_echo)
@@ -98,7 +102,7 @@ function! s:on_response()
     if !exists('s:previous_response')
         let s:previous_response = l:current_response
     endif
-    
+
     if l:current_response != s:previous_response
         let s:previous_response = l:current_response
         for r in s:previous_response
@@ -121,7 +125,7 @@ function! s:start_buffer(height)
     let g:intero_job_id = b:terminal_job_id
     quit
     call feedkeys("\<ESC>")
-    call timer_start(100, 's:on_response', {'repeat':-1})
+    call timer_start(100, function('s:on_response'), {'repeat':-1})
     return l:buffer_id
 endfunction
 

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -63,7 +63,7 @@ endfunction
 function! intero#repl#insert_type()
     let g:intero_should_echo = 0
     call intero#repl#send(intero#util#make_command(':type-at'))
-    call timer_start(100, 's:paste_type', { 'repeat': 1 })
+    call timer_start(100, function('s:paste_type'), { 'repeat': 1 })
 endfunction
 
 function! intero#repl#reload()
@@ -82,7 +82,7 @@ endfunction
 " Private:
 """"""""""
 
-function s:paste_type()
+function s:paste_type(timer)
     let l:signature = join(intero#repl#get_last_response(), "\n")
     call append(line(".")-1, l:signature)
 endfunction


### PR DESCRIPTION
Function references apparently should use `function()` in order to correctly track `<SID>`. Additionally, `timer_start` invokes its callback with the timer as the first argument.

Fixes #26 