### PR TITLE
Compile Intero asynchronously.

### DIFF
--- a/after/ftplugin/haskell/intero.vim
+++ b/after/ftplugin/haskell/intero.vim
@@ -54,6 +54,4 @@ let b:undo_ftplugin .= join(map([
             \ ], '"delcommand " . v:val'), ' | ')
 let b:undo_ftplugin .= ' | unlet b:did_ftplugin_intero'
 
-call intero#process#start()
-
 " vim: set ts=4 sw=4 et fdm=marker:


### PR DESCRIPTION
This PR moves the `stack build intero` command into a separate job, so that it doesn't block the UI. It also ensures that compilation only happens once - if it fails, it will not be retried as long as Neovim is running.

Fixes #28, and possibly #24 as well (haven't checked).