### PR TITLE
Define commands globally

### DIFF
--- a/after/ftplugin/haskell/intero.vim
+++ b/after/ftplugin/haskell/intero.vim
@@ -3,10 +3,6 @@ if exists('b:did_ftplugin_intero') && b:did_ftplugin_intero
 endif
 let b:did_ftplugin_intero = 1
 
-if !has('patch-7.4.1578')
-    echom "This version of intero-neovim requires the `timer_start` feature, which your neovim version lacks."
-    finish
-endif
 call intero#process#ensure_installed()
 
 if exists('b:undo_ftplugin')
@@ -14,33 +10,6 @@ if exists('b:undo_ftplugin')
 else
     let b:undo_ftplugin = ''
 endif
-
-" Starts the Intero process in the background.
-command! -buffer -nargs=0 -bang InteroStart call intero#process#start()
-" Kills the Intero process.
-command! -buffer -nargs=0 -bang InteroKill call intero#process#kill()
-" Opens the Intero buffer.
-command! -buffer -nargs=0 -bang InteroOpen call intero#process#open()
-" Hides the Intero buffer.
-command! -buffer -nargs=0 -bang InteroHide call intero#process#hide()
-" Loads the current module in Intero.
-command! -buffer -nargs=0 -bang InteroLoadCurrentModule call intero#repl#load_current_module()
-" Prompts user for a string to eval
-command! -buffer -nargs=0 -bang InteroEval call intero#repl#eval()
-" Gets the specific type at the current point
-command! -buffer -nargs=0 -bang InteroType call intero#repl#type(0)
-" Gets the type at the current point
-command! -buffer -nargs=0 -bang InteroGenericType call intero#repl#type(1)
-" Gets info for the identifier at the current point
-command! -buffer -nargs=0 -bang InteroInfo call intero#repl#info()
-" Go to definition of item under cursor
-command! -buffer -nargs=0 -bang InteroGoToDef call intero#loc#go_to_def()
-" Insert type of thing below cursor
-command! -buffer -nargs=0 -bang InteroTypeInsert call intero#repl#insert_type()
-" Reload
-command! -buffer -nargs=0 -bang InteroReload call intero#repl#reload()
-" Highlight uses of the identifier under cursor
-command! -buffer -nargs=0 -bang InteroUses call intero#repl#uses() | set hlsearch
 
 let b:undo_ftplugin .= join(map([
             \ 'InteroType',

--- a/after/ftplugin/haskell/intero.vim
+++ b/after/ftplugin/haskell/intero.vim
@@ -1,7 +1,7 @@
-if exists('b:did_ftplugin_intero') && b:did_ftplugin_intero
+if exists('g:did_ftplugin_intero') && g:did_ftplugin_intero
     finish
 endif
-let b:did_ftplugin_intero = 1
+let g:did_ftplugin_intero = 1
 
 call intero#process#ensure_installed()
 
@@ -11,16 +11,6 @@ else
     let b:undo_ftplugin = ''
 endif
 
-let b:undo_ftplugin .= join(map([
-            \ 'InteroType',
-            \ 'InteroGenericType',
-            \ 'InteroOpen',
-            \ 'InteroKill',
-            \ 'InteroHide',
-            \ 'InteroLoadCurrentModule',
-            \ 'InteroEval',
-            \ 'InteroGoToDef',
-            \ ], '"delcommand " . v:val'), ' | ')
-let b:undo_ftplugin .= ' | unlet b:did_ftplugin_intero'
+let b:undo_ftplugin .= 'unlet g:did_ftplugin_intero'
 
 " vim: set ts=4 sw=4 et fdm=marker:

--- a/after/ftplugin/haskell/intero.vim
+++ b/after/ftplugin/haskell/intero.vim
@@ -1,7 +1,7 @@
-if exists('g:did_ftplugin_intero') && g:did_ftplugin_intero
+if exists('b:did_ftplugin_intero') && b:did_ftplugin_intero
     finish
 endif
-let g:did_ftplugin_intero = 1
+let b:did_ftplugin_intero = 1
 
 call intero#process#ensure_installed()
 
@@ -11,6 +11,6 @@ else
     let b:undo_ftplugin = ''
 endif
 
-let b:undo_ftplugin .= 'unlet g:did_ftplugin_intero'
+let b:undo_ftplugin .= 'unlet b:did_ftplugin_intero'
 
 " vim: set ts=4 sw=4 et fdm=marker:

--- a/after/ftplugin/haskell/intero.vim
+++ b/after/ftplugin/haskell/intero.vim
@@ -3,6 +3,12 @@ if exists('b:did_ftplugin_intero') && b:did_ftplugin_intero
 endif
 let b:did_ftplugin_intero = 1
 
+if !has('patch-7.4.1578')
+    " Don't need to display the error message a second time, since it was
+    " already displayed in plugin/intero.vim
+    finish
+endif
+
 call intero#process#ensure_installed()
 
 if exists('b:undo_ftplugin')

--- a/after/ftplugin/lhaskell/intero.vim
+++ b/after/ftplugin/lhaskell/intero.vim
@@ -1,1 +1,1 @@
-../haskell/ghcmod.vim
+../haskell/intero.vim

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -1,7 +1,7 @@
-if exists('b:did_plugin_intero') && b:did_plugin_intero
+if exists('g:did_plugin_intero') && g:did_plugin_intero
     finish
 endif
-let b:did_plugin_intero = 1
+let g:did_plugin_intero = 1
 
 if !has('patch-7.4.1578')
     echom "This version of intero-neovim requires the `timer_start` feature, which your neovim version lacks."

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -1,1 +1,39 @@
+if exists('b:did_plugin_intero') && b:did_plugin_intero
+    finish
+endif
+let b:did_plugin_intero = 1
 
+if !has('patch-7.4.1578')
+    echom "This version of intero-neovim requires the `timer_start` feature, which your neovim version lacks."
+    finish
+endif
+
+" Starts the Intero process in the background.
+command! -nargs=0 -bang InteroStart call intero#process#start()
+" Kills the Intero process.
+command! -nargs=0 -bang InteroKill call intero#process#kill()
+" Opens the Intero buffer.
+command! -nargs=0 -bang InteroOpen call intero#process#open()
+" Hides the Intero buffer.
+command! -nargs=0 -bang InteroHide call intero#process#hide()
+" Loads the current module in Intero.
+command! -nargs=0 -bang InteroLoadCurrentModule call intero#repl#load_current_module()
+" Prompts user for a string to eval
+command! -nargs=0 -bang InteroEval call intero#repl#eval()
+" Gets the specific type at the current point
+command! -nargs=0 -bang InteroType call intero#repl#type(0)
+" Gets the type at the current point
+command! -nargs=0 -bang InteroGenericType call intero#repl#type(1)
+" Gets info for the identifier at the current point
+command! -nargs=0 -bang InteroInfo call intero#repl#info()
+" Go to definition of item under cursor
+command! -nargs=0 -bang InteroGoToDef call intero#loc#go_to_def()
+" Insert type of thing below cursor
+command! -nargs=0 -bang InteroTypeInsert call intero#repl#insert_type()
+" Reload
+command! -nargs=0 -bang InteroReload call intero#repl#reload()
+" Highlight uses of the identifier under cursor
+command! -nargs=0 -bang InteroUses call intero#repl#uses() | set hlsearch
+
+
+" vim: set ts=4 sw=4 et fdm=marker:


### PR DESCRIPTION
This PR moves the definition of the commands, so that they are available in all buffers, instead of just the Haskell buffers.

This is desirable so that we can, for example, reload Intero while editing .cabal files. It also eliminates some error messages that were shown if a non-Haskell file was open when existing, since InteroKill would not be  defined in the active buffer.