### PR TITLE
Fix intero#util#path_to_module()

### DIFF
--- a/autoload/intero/loc.vim
+++ b/autoload/intero/loc.vim
@@ -13,7 +13,7 @@ function! intero#loc#get_identifier_information()
     " Returns information about the identifier under the point. Return type is
     " a dictionary with the keys 'module', 'line', 'beg_col', 'end_col', and
     " 'identifier'.
-    let l:module = intero#util#path_to_module(expand('%'))
+    let l:module = intero#detect_module()
     let l:line = line('.')
     let l:identifier = intero#util#get_haskell_identifier()
     let l:winview = winsaveview()

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -18,7 +18,7 @@ endfunction
 function! intero#util#path_to_module(path)
     " Converts a path like `src/Main/Foo/Bar.hs` to Main.Foo.Bar
     return substitute(
-        \ join(split(substitute(a:path, "^[A-Z ]*/", "", ""), '/') , '.'),
+        \ join(split(substitute(a:path, "^[A-Za-z ]*/", "", ""), '/') , '.'),
         \ "\.hs", "", "")
 endfunction
 

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -15,13 +15,6 @@ function! intero#util#get_intero_window()
     return bufwinnr('stack ' .  intero#util#stack_opts() . ' ghci --with-ghc intero')
 endfunction
 
-function! intero#util#path_to_module(path)
-    " Converts a path like `src/Main/Foo/Bar.hs` to Main.Foo.Bar
-    return substitute(
-        \ join(split(substitute(a:path, "^[A-Za-z ]*/", "", ""), '/') , '.'),
-        \ "\.hs", "", "")
-endfunction
-
 function! intero#util#make_command(cmd)
     let info = intero#loc#get_identifier_information()
     return join([a:cmd, info.module, info.line, info.beg_col, info.line, info.end_col, info.identifier], ' ')


### PR DESCRIPTION
Fix the issue that intero#util#path_to_module() cannot correctly remove the prefixing "src/" from the path.