### PR TITLE
Response parsing rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ autocompletion using `deoplete` or `omnicomplete`. If you have good reason for
 wanting Intero-provided completion, please [post in the related
 issue](https://github.com/parsonsmatt/intero-neovim/issues/5).
 
+## Known Issues
+* some commands may have unexpected side-effects if you have a autocmd that automatically switches to insert mode when entering a terminal buffer
+
 ## License
 
 [BSD3 License](http://www.opensource.org/licenses/BSD-3-Clause), the same license as ghcmod-vim.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ nnoremap <Leader>hiu :InteroUses<CR>
 autocmd! BufWritePost *.hs InteroReload
 ```
 
-If you need to use a specific `stack.yaml` file, you can set either of `STACK_YAML`
-or `g:intero_stack_yaml` before invoking a command.
-
 ![REPL demo](demo-repl-lo.gif)
+
+## Commands
 
 The following commands are available:
 
@@ -100,6 +99,15 @@ first.
 ### `InteroKill`
 
 Kills the Intero process and buffer.
+
+## Configuration
+
+If you need to use a specific `stack.yaml` file, you can set either of `STACK_YAML`
+or `g:intero_stack_yaml` before invoking a command.
+
+If you use a custom prompt in GHCi, then you may need to modify the regex for it. The default is
+
+    let g:Intero_prompt_regex = '[^-]> $'
 
 ## Completion
 

--- a/autoload/intero/loc.vim
+++ b/autoload/intero/loc.vim
@@ -6,7 +6,7 @@
 
 function! intero#loc#go_to_def()
     call intero#repl#send(intero#util#make_command(':loc-at'))
-    call timer_start(100, function('s:do_the_hop'), { 'repeat': 1 })
+    call intero#process#add_handler(function('s:handle_loc'))
 endfunction
 
 function! intero#loc#get_identifier_information()
@@ -30,8 +30,8 @@ endfunction
 " Private:
 """"""""""
 
-function! s:do_the_hop(timer)
-    let l:response = join(intero#repl#get_last_response(), "\n")
+function! s:handle_loc(resp)
+    let l:response = join(a:resp, "\n")
     let l:split = split(l:response, ':')
     if len(l:split) != 2
         echom l:response

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -191,6 +191,10 @@ EOF
         let s:ansi_re_init = 1
     endif
 
+    if !exists('g:intero_prompt_regex')
+        let g:Intero_prompt_regex = '[^-]> $'
+    endif
+
     for line_seg in a:lines
         let s:current_line = s:current_line . l:line_seg
 
@@ -206,8 +210,7 @@ EOF
         endif
 
         " If the current line is a prompt, we just completed a response
-        " TODO: make this configurable
-        if s:current_line =~ '[^-]> $'
+        if s:current_line =~ g:intero_prompt_regex
             echom string(['new response', s:current_line, s:current_response])
 
             if len(s:current_response) > 0

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -5,6 +5,18 @@
 " includes ensuring that Intero is installed, starting/killing the
 " process, and hiding/showing the REPL.
 """""""""""
+" Lines of output consistuting of a command and the response to it
+let s:current_response = []
+
+" The current (incomplete) line
+let s:current_line = ''
+
+" Whether Intero has finished starting yet
+let g:intero_started = 0
+
+" If true, echo the next response. Reset after each response.
+let g:intero_echo_next = 0
+
 
 function! intero#process#ensure_installed()
     " This function ensures that intero is installed. If `stack` exits with a
@@ -104,41 +116,6 @@ endfunction
 " Private:
 """"""""""
 
-function! s:term_buffer(job_id, data, event)
-    " let g:intero_last_response = intero#repl#get_last_response()
-endfunction
-
-function! s:on_response(timer)
-    if !exists('g:intero_buffer_id')
-      return
-    endif
-
-    let l:mode = mode()
-
-    if ! (exists('g:intero_should_echo') && g:intero_should_echo)
-        return
-    endif
-
-    if l:mode =~ "c" || l:mode =~ "t"
-        return
-    endif
-
-    let l:current_response = intero#repl#get_last_response()
-
-    if !exists('s:previous_response')
-        let s:previous_response = l:current_response
-    endif
-
-    if l:current_response != s:previous_response
-        let s:previous_response = l:current_response
-        for r in s:previous_response
-            echom r
-        endfor
-        echo join(s:previous_response, "\n")
-        let g:intero_should_echo = 0
-    endif
-endfunction
-
 function! s:start_compile(height, opts)
     " Starts an Intero compiling in a split below the current buffer.
     " Returns the ID of the buffer.
@@ -146,8 +123,6 @@ function! s:start_compile(height, opts)
 
     enew!
     call termopen('stack ' . intero#util#stack_opts() . ' build intero', a:opts)
-    " startinsert
-    " exe 'terminal! stack ' . intero#util#stack_opts() . ' build intero'
 
     set bufhidden=hide
     set noswapfile
@@ -155,7 +130,6 @@ function! s:start_compile(height, opts)
     let l:buffer_id = bufnr('%')
     let g:intero_job_id = b:terminal_job_id
     call feedkeys("\<ESC>")
-    call timer_start(100, function('s:on_response'), {'repeat':-1})
     wincmd w
     return l:buffer_id
 endfunction
@@ -164,7 +138,15 @@ function! s:start_buffer(height)
     " Starts an Intero REPL in a split below the current buffer. Returns the
     " ID of the buffer.
     exe 'below ' . a:height . ' split'
-    exe 'terminal! stack ' . intero#util#stack_opts() . ' ghci --with-ghc intero'
+
+    enew
+    py import os.path
+    let l:stack_dir = pyeval('os.path.dirname("' . g:intero_stack_yaml . '")')
+    call termopen('stack ' . intero#util#stack_opts() . ' ghci --with-ghc intero', {
+                \ 'on_stdout': function('s:on_stdout'),
+                \ 'cwd': l:stack_dir
+                \ })
+
     set bufhidden=hide
     set noswapfile
     set hidden
@@ -172,8 +154,77 @@ function! s:start_buffer(height)
     let g:intero_job_id = b:terminal_job_id
     quit
     call feedkeys("\<ESC>")
-    call timer_start(100, function('s:on_response'), {'repeat':-1})
     return l:buffer_id
+endfunction
+
+function! s:on_stdout(jobid, lines, event)
+    for line_seg in a:lines
+        let s:current_line = s:current_line . l:line_seg
+
+        " If we've found a newline, flush the line buffer
+        if s:current_line =~ '\r$'
+            " Remove trailing newline
+            let s:current_line = substitute(s:current_line, '\r$', '', '')
+
+            " Using Python because raw strings make this much easier to read
+            if !exists('s:ansi_re_init')
+                python << EOF
+import re
+regexes = [
+    # Filter out ANSI codes - they are needed for interactive use, but we don't care about them.
+    # Regex from: https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+    # Note that we replace [0-?] with [0-Z] to filter out the arrow keys as well (xterm codes)
+    re.compile(r"(\x9B|\x1B\[)[0-Z]*[ -\/]*[@-~]"),
+    # Filter out DECPAM/DECPNM, since they're emitted as well
+    # Source: https://www.xfree86.org/4.8.0/ctlseqs.html
+    re.compile(r"\x1B[>=]")
+    ]
+def strip_ansi():
+    current_line = vim.eval('s:current_line')
+
+    for r in regexes:
+        current_line = r.sub("", current_line)
+
+    return current_line
+EOF
+                let s:ansi_re_init = 1
+            endif
+
+            let s:current_line = pyeval('strip_ansi()')
+
+            " Flush line buffer
+            let s:current_response = s:current_response + [s:current_line]
+            let s:current_line = ''
+        endif
+
+        " If the current line is a prompt, we just completed a response
+        if s:current_line =~ '> $'
+            if len(s:current_response) > 0
+                " The first line is the input command, so we discard it
+                call s:new_response(s:current_response[1:])
+            endif
+
+            let s:current_response = []
+        endif
+
+    endfor
+endfunction
+
+function! s:new_response(response)
+    " This means that Intero is now available to run commands
+    " TODO: ignore commands until this is set
+    if !g:intero_started
+        echom 'Intero started'
+        let g:intero_started = 1
+    endif
+
+    " For debugging
+    let g:intero_response = a:response
+
+    if g:intero_echo_next
+        echo join(a:response, "\n")
+        let g:intero_echo_next = 0
+    endif
 endfunction
 
 function! s:open_window(height)

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -215,7 +215,6 @@ EOF
 
             if len(s:current_response) > 0
                 " The first line is the input command, so we discard it
-                " echoerr string(['DEBUG', s:current_response])
                 call s:new_response(s:current_response[1:])
             endif
 

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -18,7 +18,7 @@ function! intero#repl#eval(...)
         return
     endif
 
-    let g:intero_should_echo = 1
+    let g:intero_echo_next = 1
     call intero#repl#send(l:eval)
 endfunction
 

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -47,10 +47,6 @@ function! intero#repl#info()
     call intero#repl#eval(':info ' . l:ident)
 endfunction
 
-function! intero#repl#get_last_response()
-    return s:get_last_response()
-endfunction
-
 function! intero#repl#send(str)
     " Sends a:str to the Intero REPL.
     if !exists('g:intero_buffer_id')
@@ -61,9 +57,8 @@ function! intero#repl#send(str)
 endfunction
 
 function! intero#repl#insert_type()
-    let g:intero_should_echo = 0
+    call intero#process#add_handler(function('s:paste_type'))
     call intero#repl#send(intero#util#make_command(':type-at'))
-    call timer_start(100, function('s:paste_type'), { 'repeat': 1 })
 endfunction
 
 function! intero#repl#reload()
@@ -82,90 +77,7 @@ endfunction
 " Private:
 """"""""""
 
-function s:paste_type(timer)
-    let l:signature = intero#repl#get_last_response()
-    call append(line(".")-1, l:signature)
+function s:paste_type(response)
+    call append(line(".")-1, a:response)
 endfunction
 
-function! s:get_last_response()
-    let l:prompt = s:get_last_line()
-
-    call s:switch_to_repl()
-
-    " Find the last two instances of the prompt.
-    call cursor(line('$'), 0)
-    let l:last_prompt_line = search(l:prompt, 'b')
-    let l:prev_prompt_line = search(l:prompt, 'b')
-    call cursor(line('$'), 0)
-
-    " For a reason that escapes me, it's possible for these values to be the
-    " wrong way around (possible race condition?)
-    if l:last_prompt_line < l:prev_prompt_line
-        let l:tmp = l:last_prompt_line
-        let l:last_prompt_line = l:prev_prompt_line
-        let l:prev_prompt_line = l:tmp
-    endif
-
-
-    if l:last_prompt_line == 0 || l:prev_prompt_line == 0
-        " The last line is unique, which means there's no response yet
-        let l:ret = []
-        echoerr 'Could not find prompt: ' l:prompt
-    else
-        let l:ret = getbufline(g:intero_buffer_id, l:prev_prompt_line + 1, l:last_prompt_line - 1)
-    endif
-
-    if len(l:ret) == 0
-        echoerr 'Failed to find info'
-        echo [l:prompt, l:prev_prompt_line, l:last_prompt_line, l:ret]
-    endif
-
-    call s:return_from_repl()
-
-    return l:ret
-endfunction
-
-function! s:repl_hidden()
-    " Returns whether or not the Intero repl is hidden.
-    return -1 == intero#util#get_intero_window()
-endfunction
-
-function! s:switch_to_repl()
-    " Switches to the REPL. Use with return_from_repl.
-    let s:current_window = winnr()
-    let l:i_win = intero#util#get_intero_window()
-
-    if l:i_win == -1
-        " Intero window not found. Open and close it.
-        call intero#process#open()
-        let l:i_win = intero#util#get_intero_window()
-        exe 'silent! ' . l:i_win . ' wincmd w'
-    else
-        " Intero window available. Don't close it.
-        exe 'silent! ' . l:i_win . ' wincmd w'
-        let b:dont_close_intero_window = 1
-    endif
-endfunction
-
-function! s:return_from_repl()
-    " Returns to the current window from the REPL.
-    if ! exists('s:current_window')
-        echom "No current window."
-        return
-    endif
-
-    if exists('b:dont_close_intero_window')
-        unlet b:dont_close_intero_window
-    else
-        call intero#process#hide()
-    endif
-
-    exe s:current_window . 'wincmd w'
-endfunction
-
-function! s:get_last_line()
-    " Retrieves the last non-blank line from the Intero repl, which should be
-    " a prompt.
-    python import vim
-    return pyeval('filter(lambda s: len(s) != 0, vim.buffers[int(vim.eval("g:intero_buffer_id"))])[-1]')
-endfunction

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -3,11 +3,6 @@ if exists('g:did_plugin_intero') && g:did_plugin_intero
 endif
 let g:did_plugin_intero = 1
 
-if !has('patch-7.4.1578')
-    echom "This version of intero-neovim requires the `timer_start` feature, which your neovim version lacks."
-    finish
-endif
-
 " Starts the Intero process in the background.
 command! -nargs=0 -bang InteroStart call intero#process#start()
 " Kills the Intero process.


### PR DESCRIPTION
This PR rewrites the logic used for parsing the response to a command. It's a fairly major change, so I wanted to get some feedback on it before merging.

The previous use of timers was problematic in that it:
* got the last line and assumed it was the prompt (false if we were still starting up or the last line was blank)
* sometimes inserted control characters or other extra output
* was being duplicated in each file that used it
* used a hardcoded polling frequency (1/100 ms), which made it less responsive

I've replaced with a stateful parser that is updated when the on_stdout event fires, and uses a queue of event handlers to make it pluggable.

This fixes #39, and simplifies the implementation of #10 and possibly flychecking.