### PR TITLE
Add :InteroLoadCurrentFile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ nnoremap <Leader>hio :InteroOpen<CR>
 nnoremap <Leader>hik :InteroKill<CR>
 nnoremap <Leader>hic :InteroHide<CR>
 nnoremap <Leader>hil :InteroLoadCurrentModule<CR>
+nnoremap <Leader>hif :InteroLoadCurrentFile<CR>
 
 " REPL commands
 nnoremap <Leader>hie :InteroEval<CR>
@@ -85,6 +86,10 @@ Issues a `:r` to the REPL, causing it to reload the current module set.
 ### `InteroLoadCurrentModule`
 
 This loads the current module.
+
+### `InteroLoadCurrentFile`
+
+This loads the current file. Useful for working with stack's global project.
 
 ### `InteroOpen`
 

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -27,6 +27,11 @@ function! intero#repl#load_current_module() abort
     call intero#repl#eval(':l ' . intero#loc#detect_module())
 endfunction
 
+function! intero#repl#load_current_file() abort
+    " Load the current file (useful for using the stack global project)
+    call intero#repl#eval(':l ' . expand('%:p'))
+endfunction
+
 function! intero#repl#type(generic) abort
     " Gets the type at the current point.
     let l:line = line('.')

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -13,6 +13,8 @@ command! -nargs=0 -bang InteroOpen call intero#process#open()
 command! -nargs=0 -bang InteroHide call intero#process#hide()
 " Loads the current module in Intero.
 command! -nargs=0 -bang InteroLoadCurrentModule call intero#repl#load_current_module()
+" Loads the current file in Intero.
+command! -nargs=0 -bang InteroLoadCurrentFile call intero#repl#load_current_file()
 " Prompts user for a string to eval
 command! -nargs=0 -bang InteroEval call intero#repl#eval()
 " Gets the specific type at the current point


### PR DESCRIPTION
This command is directly analogous to `:InteroLoadCurrentModule`.
Instead of inferring and loading a module, it loads a file.
This is useful when working with files outside of a project (for
example, one-off scripts and files using the implicit global-project.)

P.S.: Thanks for this project! It's great to be able to use Intero without
having to give up Vim 😄 