### PR TITLE
Three small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Intero needs to start a long-running GHCi process to work. By default, we start
 this whenever a Haskell buffer is opened. Setting this option to `0` defers
 starting GHCi until you run `:InteroStart` or `:InteroOpen`.
 
+### `g:intero_use_neomake`
+
+Default: 1.
+
+Neomake can detect and use Neomake to asynchronously show errors and warnings in
+the sign column. To disable using Neomake completely, set this option to `0`.
+For example, you might want this if you plan on using `intero` in conjunction
+with a plugin like [ALE](https://github.com/w0rp/ale) or
+[Syntastic](https://github.com/vim-syntastic/syntastic).
+
+Note: if you don't have Neomake, we detect that appropriately and continue
+gracefully.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ autocmd! BufWritePost *.hs InteroReload
 
 ![REPL demo](demo-repl-lo.gif)
 
+## Configuration
+
+### `g:intero_start_immediately`
+
+Default: 1.
+
+Intero needs to start a long-running GHCi process to work. By default, we start
+this whenever a Haskell buffer is opened. Setting this option to `0` defers
+starting GHCi until you run `:InteroStart` or `:InteroOpen`.
+
+
 ## Commands
 
 The following commands are available:

--- a/after/ftplugin/haskell/intero.vim
+++ b/after/ftplugin/haskell/intero.vim
@@ -3,7 +3,13 @@ if exists('b:did_ftplugin_intero') && b:did_ftplugin_intero
 endif
 let b:did_ftplugin_intero = 1
 
-call intero#process#initialize()
+if !exists('g:intero_start_immediately')
+    let g:intero_start_immediately = 1
+endif
+
+if g:intero_start_immediately
+    call intero#process#start()
+endif
 
 if exists('b:undo_ftplugin')
     let b:undo_ftplugin .= ' | '

--- a/autoload/intero/maker.vim
+++ b/autoload/intero/maker.vim
@@ -20,7 +20,7 @@ function! intero#maker#write_update(lines) abort
 
     call writefile(a:lines, s:log_file)
 
-    if exists(':NeomakeProject')
+    if g:intero_use_neomake && exists(':NeomakeProject')
         NeomakeProject intero
     endif
 endfunction

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -5,6 +5,11 @@
 " includes ensuring that Intero is installed, starting/killing the
 " process, and hiding/showing the REPL.
 """""""""""
+
+if !exists('g:intero_start_immediately')
+    let g:intero_start_immediately = 1
+endif
+
 " Lines of output consistuting of a command and the response to it
 let s:current_response = []
 
@@ -67,7 +72,9 @@ function! intero#process#initialize() abort
             call s:start_compile(10, l:opts)
         else
             let g:intero_built = 1
-            call intero#process#start()
+            if g:intero_start_immediately
+                call intero#process#start()
+            endif
         endif
     endif
 endfunction

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -6,10 +6,6 @@
 " process, and hiding/showing the REPL.
 """""""""""
 
-if !exists('g:intero_start_immediately')
-    let g:intero_start_immediately = 1
-endif
-
 " Lines of output consistuting of a command and the response to it
 let s:current_response = []
 
@@ -19,6 +15,9 @@ let s:current_line = ''
 " Whether Intero has finished starting yet
 let g:intero_started = 0
 
+" Whether Intero has done its initialization yet
+let s:intero_initialized = 0
+
 " If true, echo the next response. Reset after each response.
 let g:intero_echo_next = 0
 
@@ -27,8 +26,14 @@ let g:intero_echo_next = 0
 let s:response_handlers = []
 
 function! intero#process#initialize() abort
-    " This is the entry point. It ensures that Intero is installed, sets any
-    " global state we need, and starts it.
+    " This function initializes Intero.
+    " It sets any global states we need, builds 'intero' if needed, and emits
+    " any appropriate warnings to the user.
+
+    " We only need to initialize once
+    if s:intero_initialized
+        return
+    endif
 
     if(!exists('g:intero_built'))
         " If `stack` exits with a non-0 exit code, that means it failed to find the executable.
@@ -62,7 +67,7 @@ function! intero#process#initialize() abort
             silent! lcd -
         endif
 
-        " Either start Intero, or start compiling it.
+        " Ensure that intero is compiled
         " TODO: Verify that we have a version of intero that the plugin can work with.
         let l:version = system('stack ' . intero#util#stack_opts() . ' exec --verbosity silent -- intero --version')
         if v:shell_error
@@ -72,16 +77,19 @@ function! intero#process#initialize() abort
             call s:start_compile(10, l:opts)
         else
             let g:intero_built = 1
-            if g:intero_start_immediately
-                call intero#process#start()
-            endif
         endif
     endif
+
+    let s:intero_initialized = 1
 endfunction
 
 function! intero#process#start() abort
-    " Starts an intero terminal buffer, initially only occupying a small area.
+    " This is the entry point. It ensures that Intero is initialized, then
+    " starts an intero terminal buffer. Initially only occupies a small area.
     " Returns the intero buffer id.
+
+    call intero#process#initialize()
+
     if(!exists('g:intero_built') || g:intero_built == 0)
         echom 'Intero is still compiling'
         return
@@ -123,6 +131,8 @@ function! intero#process#open() abort
     " Opens the Intero REPL. If the REPL isn't currently running, then this
     " creates it. If the REPL is already running, this is a noop. Returns the
     " window ID.
+    call intero#process#initialize()
+
     let l:intero_win = intero#util#get_intero_window()
     if l:intero_win != -1
         return l:intero_win
@@ -259,6 +269,11 @@ endfunction
 
 function! s:hide_buffer() abort
     " This closes the Intero REPL buffer without killing the process.
+    if !s:intero_initialized
+        echom 'Intero was never started.'
+        return
+    endif
+
     let l:window_number = intero#util#get_intero_window()
     if l:window_number > 0
         exec 'silent! ' . l:window_number . 'wincmd c'

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -45,7 +45,7 @@ function! intero#process#initialize() abort
             return
         endif
 
-        if !exists(':Neomake')
+        if g:intero_use_neomake && !exists(':Neomake')
             echom 'Neomake not detected. Flychecking will be disabled.'
         endif
 

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -270,7 +270,7 @@ endfunction
 function! s:hide_buffer() abort
     " This closes the Intero REPL buffer without killing the process.
     if !s:intero_initialized
-        echom 'Intero was never started.'
+        " Intero was never started.
         return
     endif
 

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -92,7 +92,7 @@ function! intero#process#start() abort
 
     if(!exists('g:intero_built') || g:intero_built == 0)
         echom 'Intero is still compiling'
-        return
+        return -1
     endif
 
     if !exists('g:intero_buffer_id')
@@ -143,7 +143,10 @@ function! intero#process#open() abort
         normal! G
         exe 'silent! ' . l:current_window . 'wincmd w'
     else
-        call intero#process#start()
+        let l:rc = intero#process#start()
+        if l:rc < 0
+            return
+        endif
         return intero#process#open()
     endif
 endfunction

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -24,12 +24,12 @@ endfunction
 
 function! intero#repl#load_current_module() abort
     " Loads the current module, inferred from the given filename.
-    call intero#repl#eval(':l ' . intero#loc#detect_module())
+    call intero#repl#send(':l ' . intero#loc#detect_module())
 endfunction
 
 function! intero#repl#load_current_file() abort
     " Load the current file (useful for using the stack global project)
-    call intero#repl#eval(':l ' . expand('%:p'))
+    call intero#repl#send(':l ' . expand('%:p'))
 endfunction
 
 function! intero#repl#type(generic) abort

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -3,6 +3,10 @@ if exists('g:did_plugin_intero') && g:did_plugin_intero
 endif
 let g:did_plugin_intero = 1
 
+if !exists('g:intero_use_neomake')
+    let g:intero_use_neomake = 1
+endif
+
 " Starts the Intero process in the background.
 command! -nargs=0 -bang InteroStart call intero#process#start()
 " Kills the Intero process.
@@ -32,20 +36,22 @@ command! -nargs=0 -bang InteroReload call intero#repl#reload()
 " Highlight uses of the identifier under cursor
 command! -nargs=0 -bang InteroUses call intero#repl#uses() | set hlsearch
 
-" Neomake integration
-let g:neomake_intero_maker = {
-        \ 'exe': 'cat',
-        \ 'args': [intero#maker#get_log_file()],
-        \ 'errorformat':
-            \ '%-G%\s%#,' .
-            \ '%f:%l:%c:%trror: %m,' .
-            \ '%f:%l:%c:%tarning: %m,'.
-            \ '%f:%l:%c: %trror: %m,' .
-            \ '%f:%l:%c: %tarning: %m,' .
-            \ '%E%f:%l:%c:%m,' .
-            \ '%E%f:%l:%c:,' .
-            \ '%Z%m'
-    \ }
+if g:intero_use_neomake
+    " Neomake integration
+    let g:neomake_intero_maker = {
+            \ 'exe': 'cat',
+            \ 'args': [intero#maker#get_log_file()],
+            \ 'errorformat':
+                \ '%-G%\s%#,' .
+                \ '%f:%l:%c:%trror: %m,' .
+                \ '%f:%l:%c:%tarning: %m,'.
+                \ '%f:%l:%c: %trror: %m,' .
+                \ '%f:%l:%c: %tarning: %m,' .
+                \ '%E%f:%l:%c:%m,' .
+                \ '%E%f:%l:%c:,' .
+                \ '%Z%m'
+        \ }
+endif
 
 " Store the path to the plugin directory, so we can lazily load the Python module
 let g:intero_plugin_root = expand('<sfile>:p:h:h')


### PR DESCRIPTION
This PR contains three small, independent changes. I've included them all
together because I think they're all reasonably small. If you'd prefer, I can
back out any of the individual changes if you only want to keep certain parts.

- **Use `send` instead of `eval` for `:load`ing**

  The difference between `eval` and `send` is that `eval` captures the output
  of the command, prints it, then asks you to hit ENTER. `send` just carries
  right on.

  Since the output from `:load`ing a module is usually just chunder, (and
  since it gets duplicated into the REPL anyway), we should just use
  `send`.

- **Make Neomake optional**

  I'd rather use [w0rp/ale](https://github.com/w0rp/ale) for syntax checking and
  linting, which overlaps with Neomake. This commit makes using Neomake
  optional (so I don't have to see the warning all the time).

- **Add option to defer starting GHCi**

  The `intero` process is pretty heavy-weight (at least on my low-spec machine),
  and I only really need it when I'm sitting down for a long development
  session. This option lets me defer the `intero#process#start()` call until I'm
  ready.