### PR TITLE
Select load targets

### DIFF
--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -141,7 +141,7 @@ function! intero#process#restart() abort
     call intero#process#start()
 endfunction
 
-function! intero#process#restart_with_targets(...)
+function! intero#process#restart_with_targets(...) abort
     call intero#util#set_load_targets(a:000)
     call intero#process#restart()
 endfunction

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -136,20 +136,14 @@ function! intero#process#add_handler(func) abort
     let s:response_handlers = s:response_handlers + [a:func]
 endfunction
 
-function! intero#process#restart_with(...) abort
-    " If no arguments were passed, prompt the user to enter a target
-    " targets
-    if a:0 == 0
-        call inputsave()
-        let l:targets = split(input('Targets: '), ' ')
-        call inputrestore()
-    else 
-        let l:targets = a:000
-    endif
-
-    call intero#util#set_load_targets(l:targets)
+function! intero#process#restart() abort
     call intero#process#kill()
     call intero#process#start()
+endfunction
+
+function! intero#process#restart_with_targets(...)
+    call intero#util#set_load_targets(a:000)
+    call intero#process#restart()
 endfunction
 
 """"""""""

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -269,3 +269,11 @@ function! s:build_complete(job_id, data, event) abort
     endif
 endfunction
 
+function! s:load_targets_from_stack() abort
+    let g:intero_load_targets = systemlist('stack ide targets')
+endfunction
+
+if (!exists('g:intero_load_targets'))
+    " A list of load targets.
+    call s:load_targets_from_stack()
+endif

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -137,15 +137,17 @@ function! intero#process#add_handler(func) abort
 endfunction
 
 function! intero#process#restart_with(...) abort
-    " If no arguments were passed, use the current value of intero load
+    " If no arguments were passed, prompt the user to enter a target
     " targets
     if a:0 == 0
-        call intero#process#kill()
-        call intero#process#start()
-        return
+        call inputsave()
+        let l:targets = split(input('Targets: '), ' ')
+        call inputrestore()
+    else 
+        let l:targets = a:000
     endif
 
-    call intero#util#set_load_targets(a:000)
+    call intero#util#set_load_targets(l:targets)
     call intero#process#kill()
     call intero#process#start()
 endfunction

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -85,14 +85,29 @@ endif
 " Attempt to set the load targets. When passed an empty array, this uses the
 " targets as given by `stack ide targets`.
 function! intero#util#set_load_targets(targets) abort
-    let l:stack_targets = s:load_targets_from_stack()
     if len(a:targets) == 0
         let g:intero_load_targets = l:stack_targets
         return g:intero_load_targets
     endif
 
+    " if stack targets are empty, then we are not in a stack project.
+    " attempting to set the targets will cause the build command to fail.
+    let l:stack_targets = s:load_targets_from_stack()
+    if empty(l:stack_targets)
+        let g:intero_load_targets = []
+        return g:intero_load_targets
+    endif
+
+    " we are in a stack project, and there are desired targets. validate that
+    " they are contained inside the stack load targets
+    for target in a:targets
+        if index(l:stack_targets, target) == -1
+            call intero#util#print_warning("Target " . target . " not present in available Stack targets: " . join(l:stack_targets, ' '))
+        endif
+    endfor
+
     let g:intero_load_targets = a:targets
-    return a:targets
+    return g:intero_load_targets
 endfunction
 
 function! intero#util#get_load_targets()

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -9,6 +9,10 @@ function! intero#util#stack_opts() abort
     return '--stack-yaml ' . g:intero_stack_yaml
 endfunction
 
+function! intero#util#stack_build_opts() abort
+    return intero#util#load_targets_as_string()
+endfunction
+
 function! intero#util#get_intero_window() abort
     " Returns the window ID that the Intero process is on, or -1 if it isn't
     " found.
@@ -69,4 +73,33 @@ function! intero#util#tocol(line, col) abort "{{{
     return l:len + 1
 endfunction "}}}
 
+function! s:load_targets_from_stack() abort
+    return systemlist('stack ide targets')
+endfunction
+
+if (!exists('g:intero_load_targets'))
+    " A list of load targets.
+    let g:intero_load_targets = []
+endif
+
+" Attempt to set the load targets. When passed an empty array, this uses the
+" targets as given by `stack ide targets`.
+function! intero#util#set_load_targets(targets) abort
+    let l:stack_targets = s:load_targets_from_stack()
+    if len(a:targets) == 0
+        let g:intero_load_targets = l:stack_targets
+        return g:intero_load_targets
+    endif
+
+    let g:intero_load_targets = a:targets
+    return a:targets
+endfunction
+
+function! intero#util#get_load_targets()
+    return g:intero_load_targets
+endfunction
+
+function! intero#util#load_targets_as_string()
+    return join(intero#util#get_load_targets(), ' ')
+endfunction
 " vim: set ts=4 sw=4 et fdm=marker:

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -101,11 +101,11 @@ function! intero#util#set_load_targets(targets) abort
     let l:valid_targets = []
     " we are in a stack project, and there are desired targets. validate that
     " they are contained inside the stack load targets
-    for target in a:targets
-        if index(l:stack_targets, target) == -1
-            call intero#util#print_warning("Target " . target . " not present in available Stack targets: " . join(l:stack_targets, ' '))
+    for l:target in a:targets
+        if index(l:stack_targets, l:target) == -1
+            call intero#util#print_warning("Target " . l:target . " not present in available Stack targets: " . join(l:stack_targets, ' '))
         else 
-            call add(l:valid_targets, target)
+            call add(l:valid_targets, l:target)
         endif
     endfor
 
@@ -113,11 +113,11 @@ function! intero#util#set_load_targets(targets) abort
     return g:intero_load_targets
 endfunction
 
-function! intero#util#get_load_targets()
+function! intero#util#get_load_targets() abort
     return g:intero_load_targets
 endfunction
 
-function! intero#util#load_targets_as_string()
+function! intero#util#load_targets_as_string() abort
     return join(intero#util#get_load_targets(), ' ')
 endfunction
 " vim: set ts=4 sw=4 et fdm=marker:

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -86,7 +86,7 @@ endif
 " targets as given by `stack ide targets`.
 function! intero#util#set_load_targets(targets) abort
     if len(a:targets) == 0
-        let g:intero_load_targets = l:stack_targets
+        let g:intero_load_targets = s:load_targets_from_stack()
         return g:intero_load_targets
     endif
 
@@ -100,11 +100,13 @@ function! intero#util#set_load_targets(targets) abort
 
     " we are in a stack project, and there are desired targets. validate that
     " they are contained inside the stack load targets
-    for target in a:targets
-        if index(l:stack_targets, target) == -1
-            call intero#util#print_warning("Target " . target . " not present in available Stack targets: " . join(l:stack_targets, ' '))
-        endif
-    endfor
+""    for target in a:targets
+""        if index(l:stack_targets, target) == -1
+""            call intero#util#print_warning("Target " . target . " not present in available Stack targets: " . join(l:stack_targets, ' '))
+""        endif
+""    endfor
+
+    call s:multiple_options(g:intero_load_targets, l:stack_targets)
 
     let g:intero_load_targets = a:targets
     return g:intero_load_targets
@@ -117,4 +119,67 @@ endfunction
 function! intero#util#load_targets_as_string()
     return join(intero#util#get_load_targets(), ' ')
 endfunction
+
+" The following bit of code is derived from an answer by user852573 from stack
+" overflow: https://stackoverflow.com/questions/45018608/how-to-prompt-a-user-for-multiple-entries-in-a-list/45020776#45020776
+
+function! s:multiple_options(current_opts, stack_opts) abort
+    vnew | exe 'vert resize '.(&columns/3)
+    setl bh=wipe bt=nofile nobl noswf nowrap
+    if !bufexists('Select Intero Targets') | silent file Select\ Intero\ Targets | endif
+
+    silent! 0put = a:stack_opts
+    silent! $d_
+    setl noma ro
+
+    let w:options_chosen = { 'lines': a:current_opts, 'pattern': '', 'id': 0 }
+    let w:options_chosen.pattern = '\v'.join(map(
+                                \               copy(w:options_chosen.lines),
+                                \               "'%'.v:val.'l'"
+                                \              ), '|')
+
+    let w:options_chosen.id = !empty(w:options_chosen.lines)
+                            \   ? matchadd('IncSearch', w:options_chosen.pattern)
+                            \   : 0
+
+    nno <silent> <buffer> <nowait> q     :<c-u>call <sid>close()<cr>
+    nno <silent> <buffer> <nowait> <cr>  :<c-u>call <sid>select_option()<cr>
+endfunction
+
+function! s:close() abort
+    let l:opts = s:load_targets_from_stack()
+    let g:intero_load_targets = map(w:options_chosen.lines, {k, v -> l:opts[v-1] })
+    close
+endfunction
+
+function! s:select_option() abort
+    if !exists('w:options_chosen')
+        let w:options_chosen = {
+                               \ 'lines'  : [],
+                               \ 'pattern' : '',
+                               \ 'id'      : 0,
+                               \ }
+    else
+        if w:options_chosen.id
+            call matchdelete(w:options_chosen.id)
+            let w:options_chosen.pattern .= '|'
+        endif
+    endif
+
+    if !empty(w:options_chosen.lines) && count(w:options_chosen.lines, line('.'))
+        call filter(w:options_chosen.lines, "v:val != line('.')")
+    else
+        let w:options_chosen.lines += [ line('.') ]
+    endif
+
+    let w:options_chosen.pattern = '\v'.join(map(
+                                \               copy(w:options_chosen.lines),
+                                \               "'%'.v:val.'l'"
+                                \              ), '|')
+
+    let w:options_chosen.id = !empty(w:options_chosen.lines)
+                            \   ? matchadd('IncSearch', w:options_chosen.pattern)
+                            \   : 0
+endfunction
+
 " vim: set ts=4 sw=4 et fdm=marker:

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -103,7 +103,7 @@ function! intero#util#set_load_targets(targets) abort
     " they are contained inside the stack load targets
     for l:target in a:targets
         if index(l:stack_targets, l:target) == -1
-            call intero#util#print_warning("Target " . l:target . " not present in available Stack targets: " . join(l:stack_targets, ' '))
+            call intero#util#print_warning('Target ' . l:target . ' not present in available Stack targets: ' . join(l:stack_targets, ' '))
         else 
             call add(l:valid_targets, l:target)
         endif

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -31,11 +31,10 @@ command! -nargs=0 -bang InteroTypeInsert call intero#repl#insert_type()
 command! -nargs=0 -bang InteroReload call intero#repl#reload()
 " Highlight uses of the identifier under cursor
 command! -nargs=0 -bang InteroUses call intero#repl#uses() | set hlsearch
-" Kill and restart the Intero process with the given targets. If no targets
-" are passed, then this prompts for them.
-command! -nargs=* -bang InteroRestartWith call intero#process#restart_with(<f-args>)
 " Kill and restart the Intero process
-command! -nargs=0 -bang InteroRestart call intero#process#restart_with([])
+command! -nargs=0 -bang InteroRestart call intero#process#restart()
+" Set the load targets for Intero.
+command! -nargs=* -bang InteroSetTargets call intero#process#restart_with_targets(<f-args>)
 
 " Neomake integration
 let g:neomake_intero_maker = {

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -31,6 +31,8 @@ command! -nargs=0 -bang InteroTypeInsert call intero#repl#insert_type()
 command! -nargs=0 -bang InteroReload call intero#repl#reload()
 " Highlight uses of the identifier under cursor
 command! -nargs=0 -bang InteroUses call intero#repl#uses() | set hlsearch
+" Kill and restart the Intero process with the given targets.
+command! -nargs=* -bang InteroRestartWith call intero#process#restart_with(<f-args>)
 
 " Neomake integration
 let g:neomake_intero_maker = {

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -31,8 +31,11 @@ command! -nargs=0 -bang InteroTypeInsert call intero#repl#insert_type()
 command! -nargs=0 -bang InteroReload call intero#repl#reload()
 " Highlight uses of the identifier under cursor
 command! -nargs=0 -bang InteroUses call intero#repl#uses() | set hlsearch
-" Kill and restart the Intero process with the given targets.
+" Kill and restart the Intero process with the given targets. If no targets
+" are passed, then this prompts for them.
 command! -nargs=* -bang InteroRestartWith call intero#process#restart_with(<f-args>)
+" Kill and restart the Intero process
+command! -nargs=0 -bang InteroRestart call intero#process#restart_with([])
 
 " Neomake integration
 let g:neomake_intero_maker = {


### PR DESCRIPTION
This function allows the user to select a list of load targets.

New commands:

`:InteroRestartWith`

This one accepts a list of Stack targets to load. If no targets are specified, then it prompts the user for targets. If the target doesn't exist, then it displays a warning.

TODO: Make this a select list of some sort?

`:InteroRestart`

This kills and reloads the Intero process with the currently loaded list of targets.

I'm not confident on the design or implementation of this.