### PR TITLE
Support all the Pythons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ tinytest
 verbose.log
 stdout.log
 *.pyc
+*.egg*
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ verbose.log
 stdout.log
 *.pyc
 *.egg*
-
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ python:
   - "3.6"
   - "nightly"
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: "nightly"
+
 install:
     - pip install vim-vint pylama
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ install:
 script:
     - vint .
     - pylama
+    - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
     - pip install vim-vint pylama
 
 script:
-    - vint --enable-neovim --style-problem .
+    - vint .
     - pylama

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
   - "nightly"
 
 install:
-    - pip install vim-vint flake8
+    - pip install vim-vint pylama
 
 script:
     - vint --enable-neovim --style-problem .
-    - flake8 --max-line-length=150 --ignore=W391
+    - pylama

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: python
+
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "nightly"
+
 install:
     - pip install vim-vint flake8
 
 script:
     - vint --enable-neovim --style-problem .
     - flake8 --max-line-length=150 --ignore=W391
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ matrix:
   allow_failures:
     - python: "nightly"
 
+before_install:
+    - pip install -U pip pipenv
+
 install:
-    - pip install vim-vint pylama
+    - pipenv install --dev
 
 script:
     - vint .

--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,3 @@
+cmdargs:
+  severity: style_problem
+  env: { neovim: true }

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+
+[dev-packages]
+vim-vint = "*"
+pylama = "*"
+pytest = "*"
+"-e ." = "*"
+pytest-mock = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,63 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d1645f834a4b516c7af9f7be5844857920402011c3fda1ba7491025723c331cc"
+        },
+        "requires": {},
+        "sources": [
+            {
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "-e .": "*",
+        "ansicolor": {
+            "version": "==0.2.4"
+        },
+        "chardet": {
+            "version": "==3.0.4"
+        },
+        "mccabe": {
+            "version": "==0.6.1"
+        },
+        "py": {
+            "version": "==1.4.34"
+        },
+        "pycodestyle": {
+            "version": "==2.3.1"
+        },
+        "pydocstyle": {
+            "version": "==2.0.0"
+        },
+        "pyflakes": {
+            "version": "==1.6.0"
+        },
+        "pylama": {
+            "version": "==7.4.1"
+        },
+        "pytest": {
+            "version": "==3.2.0"
+        },
+        "pytest-mock": {
+            "version": "==1.6.2"
+        },
+        "pyyaml": {
+            "version": "==3.12"
+        },
+        "setuptools": {
+            "version": "==36.2.7"
+        },
+        "six": {
+            "version": "==1.10.0"
+        },
+        "snowballstemmer": {
+            "version": "==1.2.1"
+        },
+        "vim-vint": {
+            "version": "==0.3.13"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -160,6 +160,31 @@ let g:intero_start_immediately = 0
 - Completion is not handled by this plugin. You might want to checkout out
   [neco-ghc][] if you want completion.
 
+## Contributing
+
+### Python Hacking
+
+Get your environment setup by installing [pipenv] and running:
+
+[pipenv]: http://docs.pipenv.org/en/latest/advanced.html#fancy-installation-of-pipenv
+
+``` bash
+$ pipenv install --dev
+```
+
+Your system level python installation will not be affected.
+
+Then drop into an environment activated shell with:
+
+``` bash
+$ pipenv shell
+```
+
+Then you can run the following:
+
+  * Run the tests with `pytest`
+  * Run the vim linter wiht `vint .`
+  * Run the Python code quality checker with `pylama`
 
 ## License
 

--- a/intero.py
+++ b/intero.py
@@ -1,5 +1,7 @@
-# Functions consumed from Vimscript. This file is loaded as a module, to avoid
-# polluting the global namespace.
+'''Functions consumed from Vimscript.
+
+This file is loaded as a module, to avoid polluting the global namespace.
+'''
 
 import os.path
 import re

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[pylama]
+# Ignore blank line at EOF
+ignore=W391
+
+[pylama:pycodestyle]
+max_line_length=150

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+"""Tiny package configuration for testing purposes."""
+
+from setuptools import find_packages, setup
+
+setup(
+    name='intero-neovim',
+    version='0.0.1',
+    packages=find_packages('.', exclude=['tests']),
+)

--- a/tests/test_intero.py
+++ b/tests/test_intero.py
@@ -23,6 +23,6 @@ def test_stack_dirname(mock_vim):
 def test_strip_internal(mock_vim):
     from intero import strip_internal
 
-    assert strip_internal('\ESC[38;2;255;100;0mλ> \ESC[m') == 'λ> '
+    assert strip_internal('\x1b[38;2;255;100;0mλ> \x1b[m') == 'λ> '
     assert strip_internal('\x1b[01;31mfoobar') == 'foobar'
     assert strip_internal('\x1b[?2lfoobar') == 'foobar'

--- a/tests/test_intero.py
+++ b/tests/test_intero.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+'''Unit tests for the intero.py module.'''
+
+import pytest
+
+
+@pytest.fixture
+def mock_vim(mocker):
+    mock = mocker.MagicMock()
+    mocker.patch.dict('sys.modules', vim=mock)
+    return mock
+
+
+def test_stack_dirname(mock_vim):
+    from intero import stack_dirname
+
+    example_intero_stack_yaml = '/home/foobar/stack.yaml'
+    mock_vim.configure_mock(**{'eval.return_value': example_intero_stack_yaml})
+    assert stack_dirname() == '/home/foobar'
+
+
+def test_strip_internal(mock_vim):
+    from intero import strip_internal
+
+    assert strip_internal('\ESC[38;2;255;100;0mλ> \ESC[m') == 'λ> '
+    assert strip_internal('\x1b[01;31mfoobar') == 'foobar'
+    assert strip_internal('\x1b[?2lfoobar') == 'foobar'


### PR DESCRIPTION
I chose to add [pylama](https://github.com/klen/pylama) because it uses flake8 and a whole bunch of others to do more comprehensive checks to keep things in line. Moved a bunch of configuration options into their own files as well.

This only runs static checking, if you want, I could write a few unit tests for `intero.py`?

Should close https://github.com/parsonsmatt/intero-neovim/issues/75.