### PR TITLE
Ignore installed and get latest setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "nightly"
 
 before_install:
-    - pip install -U pip pipenv
+    - pip install -IU pip pipenv
 
 install:
     - pipenv install --dev


### PR DESCRIPTION
This might fix https://github.com/parsonsmatt/intero-neovim/issues/89.