### PR TITLE
Remove pyeval

### DIFF
--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -260,7 +260,7 @@ function! s:on_stdout(jobid, lines, event) abort
         " If the current line is a prompt, we just completed a response.
         " Note that we need to strip control chars here, because otherwise
         " they're only removed when the line is added to the response.
-        if pyeval('intero.strip_control_chars("s:current_line")') =~ (g:intero_prompt_regex . '$')
+        if intero#util#strip_control_characters(s:current_line) =~ (g:intero_prompt_regex . '$')
             if len(s:current_response) > 0
                 " Separate the input command from the response
                 let l:cmd = substitute(s:current_response[0], '.*' . g:intero_prompt_regex, '', '')


### PR DESCRIPTION
There was a lingering `pyeval` from #91. This PR removes it.