### PR TITLE
Add :InteroSend command

### DIFF
--- a/doc/intero.txt
+++ b/doc/intero.txt
@@ -151,13 +151,19 @@ interact with the REPL.
                   use a vertical split use |CTRL-W_H| or |CTRL-W_L|. To move
                   it to it's own tab: |CTRL-W_T|.
 
-                                                                 *:InteroUses*
+                                                                 *:InteroEval*
 :InteroEval [cmd] Runs a command in the background process, and displays the
                   result. Useful when you don't want to have to open up the
                   full REPL.
 
                   Calling |:InteroEval| will 0 arguments will prompt you to
                   enter a command.
+
+                                                                 *:InteroSend*
+:InteroSend [cmd] Just like |:InteroEval|, but only shows the output in the
+                  Intero buffer (doesn't also echo it). This is nice when you
+                  have multi-line output that you want to keep around for a
+                  while.
 
 
 Loading Code~

--- a/plugin/intero.vim
+++ b/plugin/intero.vim
@@ -21,6 +21,8 @@ command! -nargs=0 -bang InteroLoadCurrentModule call intero#repl#load_current_mo
 command! -nargs=0 -bang InteroLoadCurrentFile call intero#repl#load_current_file()
 " Prompts user for a string to eval
 command! -nargs=? -bang InteroEval call intero#repl#eval(<f-args>)
+" Sends a string to the Intero buffer (doesn't prompt to "press any key")
+command! -nargs=? -bang InteroSend call intero#repl#send(<f-args>)
 " Gets the specific type at the current point
 command! -nargs=0 -bang InteroType call intero#repl#type(0)
 " Gets the type at the current point


### PR DESCRIPTION
Adds the `:InteroSend` command.

This is handy for doing things like this:

    " hoogle bindings
    " (prereq: stack install hoogle && hoogle generate)

    " Query hoogle for what's under the cursor, and put it in the intero buffer
    au FileType haskell noremap <silent> <leader>iq :InteroSend<SPACE>:!hoogle<SPACE><C-R><C-W><CR>
    " qUery hoogle for a User prompted string
    au FileType haskell noremap <leader>iu :InteroSend<SPACE>:!hoogle<SPACE>

We could also do this with :InteroEval, but it's annoying because for
multi-line output Vim prompts you to press Enter to continue.
Instead, I just want my hoogle output (for example) to show up
Inimmediately in the tero buffer.