### PR TITLE
Fix parsing issue

### DIFF
--- a/autoload/intero/loc.vim
+++ b/autoload/intero/loc.vim
@@ -64,8 +64,8 @@ function! s:handle_loc(resp) abort
         echom l:response
     else
         let l:loc_split = split(l:module_or_loc, '-')
-        let l:start = substitute(l:loc_split[0], '[\(\)]', '', 'g')
-        let l:end = substitute(l:loc_split[1], '[\(\)]', '', 'g')
+        let l:start = substitute(l:loc_split[0], '\m[\(\)]', '', 'g')
+        let l:end = substitute(l:loc_split[1], '\m[\(\)]', '', 'g')
         let l:start_split = split(l:start, ',')
         let l:start_row = l:start_split[0]
         let l:start_col = l:start_split[1]

--- a/autoload/intero/process.vim
+++ b/autoload/intero/process.vim
@@ -254,7 +254,7 @@ function! s:on_stdout(jobid, lines, event) abort
         " If we've found a newline, flush the line buffer
         if s:current_line =~# '\r$'
             " Remove trailing newline, control chars
-            let s:current_line = substitute(s:current_line, '\r$', '', '')
+            let s:current_line = substitute(s:current_line, '\m\r$', '', '')
             let s:current_line = intero#util#strip_control_characters(s:current_line)
 
             " Flush line buffer
@@ -268,7 +268,7 @@ function! s:on_stdout(jobid, lines, event) abort
         if intero#util#strip_control_characters(s:current_line) =~ (g:intero_prompt_regex . '$')
             if len(s:current_response) > 0
                 " Separate the input command from the response
-                let l:cmd = substitute(s:current_response[0], '.*' . g:intero_prompt_regex, '', '')
+                let l:cmd = substitute(s:current_response[0], '\m.*' . g:intero_prompt_regex, '', '')
                 call s:new_response(l:cmd, s:current_response[1:])
             endif
 

--- a/autoload/intero/util.vim
+++ b/autoload/intero/util.vim
@@ -54,7 +54,7 @@ endfunction "}}}
 
 function! intero#util#getcol(line, col) abort "{{{
     let l:str = getline(a:line)[:(a:col - 1)]
-    let l:tabcnt = len(substitute(l:str, '[^\t]', '', 'g'))
+    let l:tabcnt = len(substitute(l:str, '\m[^\t]', '', 'g'))
     return a:col + 7 * l:tabcnt
 endfunction "}}}
 
@@ -85,12 +85,13 @@ function! intero#util#strip_control_characters(line) abort
     " out the arrow keys as well (xterm codes)
     "
     " https://stackoverflow.com/questions/14693701/
-    let s:regex1 = '\v([\x9b]|[\x1b]\[)[0-Z]*[ -\/]*[@-~]'
+    " https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences
+    let s:regex1 = '\v\C([\x9b]|[\x1b]\[)[0-Z]*[ -\/]*[@-~]'
 
     " Filter out DECPAM/DECPNM, since they're emitted as well
     "
     " https://www.xfree86.org/4.8.0/ctlseqs.html
-    let s:regex2 = '\v[\x1b][>=]'
+    let s:regex2 = '\v\C[\x1b][>=]'
 
     let l:result = a:line
     let l:result = substitute(l:result, s:regex1, '', 'g')

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -9,6 +9,8 @@ unset CDPATH
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
+export VADER_OUTPUT_FILE=vader.log
 set -x
 nvim -N -u vimrc.vim -c 'Vader! **/*.vader'
+cat ${VADER_OUTPUT_FILE}
 set +x


### PR DESCRIPTION
This PR adds `\C\m` prefixes to regexes (where applicable), as otherwise case sensitivity and magic are determined by the user's config and therefore not portable.

This fixes a bug Neomake wouldn't be updated following a reload if `ignorecase` was set.