### PR TITLE
Parse GHCi version on repl startup

### DIFF
--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -44,6 +44,12 @@ function! intero#repl#load_current_file() abort
     endif
 endfunction
 
+function! s:supports_type_at() abort
+    let [l:major, l:minor, l:patch] = g:intero_ghci_version
+    " >= 8.0.1 supports :type-at
+    return l:major >= 8 && ((l:minor == 0 && l:patch >= 1) || l:minor > 0)
+endfunction
+
 " This function only gets the type of what's under the cursor.
 " For a visual selection, you MUST use the key mapping, not the command.
 function! intero#repl#type(generic) abort


### PR DESCRIPTION
Sorry, still having trouble with my fork and branches, so I accidentally closed the other PR. Here's the same one again, but with the suggested changes and based on my comment:

This is in preparation for supporting any GHCi, not only intero. We'll
need version checks to switch some features on and off, e.g. `:type` and
`:type-at` usage.

In itself, this commit shouldn't affect the behaviour, but it does some
refactoring, so please review changes to the `process.vim` file.

This commit does not add support for using something other than
`intero`.