### PR TITLE
Insert types on let and where bindings

### DIFF
--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -4,6 +4,10 @@
 " This file contains code for sending commands to the Intero REPL.
 """"""""""
 
+" Location information for the identifier to insert a type signature for. It's
+" inserted in a callback, hence this state variable.
+let s:insert_type_identifier = 0
+
 function! intero#repl#eval(...) abort
     if !g:intero_started
         echoerr 'Intero is still starting up'
@@ -119,6 +123,10 @@ function! intero#repl#insert_type() abort
     if !g:intero_started
         echoerr 'Intero is still starting up'
     else
+        " for callback to add correct indent:
+        let s:insert_type_identifier = intero#loc#get_identifier_information()
+        echo s:insert_type_identifier
+
         call intero#process#add_handler(function('s:paste_type'))
         call intero#repl#send(intero#util#make_command(':type-at'))
     endif
@@ -151,12 +159,55 @@ endfunction
 " Private:
 """"""""""
 
-function! s:paste_type(lines) abort
-    let l:message = join(a:lines, '\n')
-    if l:message =~# ' :: '
-        call append(line('.')-1, a:lines)
+" Callback that inserts a type signature for a requested definition. Inserts
+" the type signature at the definition's location, and indents the definition
+" (that gets pushed down) the correct number of spaces, to match the type
+" signature.
+function! s:paste_type(type_lines) abort
+    " First, check that the message contains a type signature. Join everything
+    " as one line to avoid multiline search problems.
+    if (join(a:type_lines) =~# ' :: ')
+        let l:col_idx = s:insert_type_identifier.beg_col - 1
+        let l:line = s:insert_type_identifier.line
+
+        " The indent as a string.
+        let l:indent = repeat(' ', l:col_idx)
+
+        let l:first = a:type_lines[0]
+        " We indent all but the first line of the type signature.
+        let l:indented = []
+        for l:type_line in a:type_lines[1:]
+            call add(l:indented, l:indent . l:type_line)
+        endfor
+
+        " The contents of the line where we're going to insert the type signature.
+        let l:old = getline(l:line)
+
+        " Calculate what to put _before_ and _after_ the inserted type signature.
+        if l:col_idx > 0
+            " When not on the top-level, everything on the same line, up until the
+            " definition, need to be reinserted before the type signature.
+            let l:prefix = l:old[0:(l:col_idx - 1)]
+            " Everything from the definition and to the end of that line needs to
+            " be added after the type signature and indent.
+            let l:suffix = l:old[(l:col_idx):]
+        else
+            " When on the top level, we don't need anything before the type
+            " signature.
+            let l:prefix = ''
+            " And everything on that line should go below the type signature.
+            let l:suffix = l:old
+        endif
+
+        " We replace the definition line with the prefix (the original indent,
+        " if any) and the unindented first line of the type signature.
+        call setline(l:line, l:prefix . l:first)
+        " And then we append the indented type signature lines, together with
+        " the suffix (the original definition line) indented to match the type
+        " signatured.
+        call append(l:line, l:indented + [l:indent . l:suffix])
     else
-        echomsg l:message
+        echomsg join(a:type_lines, '\n')
     end
 endfunction
 

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -125,7 +125,6 @@ function! intero#repl#insert_type() abort
     else
         " for callback to add correct indent:
         let s:insert_type_identifier = intero#loc#get_identifier_information()
-        echo s:insert_type_identifier
 
         call intero#process#add_handler(function('s:paste_type'))
         call intero#repl#send(intero#util#make_command(':type-at'))

--- a/test/intero/repl.vader
+++ b/test/intero/repl.vader
@@ -1,0 +1,26 @@
+Execute (is_type_signature works on single-line signature):
+    AssertEqual intero#repl#is_type_signature(["foo :: bar"]), 1
+
+Execute (is_type_signature works on multi-line signature):
+    AssertEqual intero#repl#is_type_signature(["foo", "  ::", "    bar"]), 1
+
+Execute (is_type_signature works on single-line signature):
+    AssertEqual intero#repl#is_type_signature(["foo :: bar"]), 1
+
+Execute (is_type_signature works on multi-line signature):
+    AssertEqual intero#repl#is_type_signature(["foo", "  ::", "    bar"]), 1
+
+Execute (get_type_signature_line_replacement handles top-level definition):
+    AssertEqual intero#repl#get_type_signature_line_replacement("foo = bar", ["foo :: Bar"], 1), ["foo :: Bar", "foo = bar"]
+
+Execute (get_type_signature_line_replacement handles indented definition):
+    AssertEqual intero#repl#get_type_signature_line_replacement("  foo = bar", ["foo :: Bar"], 3), ["  foo :: Bar", "  foo = bar"]
+
+Execute (get_type_signature_line_replacement handles indented definition and multi-line type signature):
+    AssertEqual intero#repl#get_type_signature_line_replacement("  foo = bar", ["foo", "  ::", "    bar"], 3), ["  foo", "    ::", "      bar", "  foo = bar"]
+
+Execute (get_type_signature_line_replacement handles definition on same line as let):
+    AssertEqual intero#repl#get_type_signature_line_replacement("  let foo = bar", ["foo :: Bar"], 7), ["  let foo :: Bar", "      foo = bar"]
+
+Execute (get_type_signature_line_replacement handles definition on same line as where):
+    AssertEqual intero#repl#get_type_signature_line_replacement("  where foo = bar", ["foo :: Bar"], 9), ["  where foo :: Bar", "        foo = bar"]


### PR DESCRIPTION
This adds support for using `:InteroTypeInsert` not only at the top-level, but in any indented where or let bindings.

I recorded an asciinema cast of this when I had implemented it in neovim-ghci, so you can see it in action there:

[![asciicast](https://asciinema.org/a/zn4vlqlBMIwoJxtQsxHOaCevd.png)](https://asciinema.org/a/zn4vlqlBMIwoJxtQsxHOaCevd)

The code is a little involved in the `s:paste_type`, so I've tried to comment and explain what's going on.