### PR TITLE
Kill previous command before sending a command

### DIFF
--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -106,6 +106,7 @@ function! intero#repl#send(str) abort
         echomsg 'Intero not running.'
         return
     endif
+    call jobsend(g:intero_job_id, ["\<C-c>", ''])
     call jobsend(g:intero_job_id, add([a:str], ''))
 endfunction
 

--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -106,8 +106,7 @@ function! intero#repl#send(str) abort
         echomsg 'Intero not running.'
         return
     endif
-    call jobsend(g:intero_job_id, ["\<C-c>", ''])
-    call jobsend(g:intero_job_id, add([a:str], ''))
+    call jobsend(g:intero_job_id, ["\<C-c>", a:str, ''])
 endfunction
 
 function! intero#repl#insert_type() abort


### PR DESCRIPTION
This PR sends a `C-c` to the REPL before sending a command. This clears the current command, which will prevent any unfinished input from clobbering the text.

Fixes #66 