### PR TITLE
Fix type_at for ghci backend

### DIFF
--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -85,15 +85,14 @@ function! intero#repl#type_at(generic, l1, c1, l2, c2) abort
     endif
 
     if s:ghci_supports_type_at_and_uses()
+        let l:module = intero#loc#detect_module()
+
         if g:intero_backend_info.backend ==# 'intero'
-            let l:module = intero#loc#detect_module()
 
             " Fixup tabs for Stack
             let l:col1 = intero#util#getcol(a:l1, a:c1)
             let l:col2 = intero#util#getcol(a:l2, a:c2)
         else
-            " Relative path to current file, quoted.
-            let l:module = '"' . @% . '"'
 
             " Weird difference where regular GHCi needs the end column to be
             " beyond the last character of the selection, as opposed to how


### PR DESCRIPTION
This fixes https://github.com/parsonsmatt/intero-neovim/issues/133 for me - i hope there is no other ghci version that behaves differently ? At least for ghc 8.0.2 and 8.2.2 this fixes it.