### PR TITLE
send C-u to the REPL before running InteroReload

### DIFF
--- a/autoload/intero/repl.vim
+++ b/autoload/intero/repl.vim
@@ -167,8 +167,17 @@ function! intero#repl#reload() abort
         " Truncate file, so that we don't show stale results while recompiling
         call intero#maker#write_update([])
 
+        call intero#repl#clear()
         call intero#repl#send(':reload')
     endif
+endfunction
+
+function! intero#repl#clear() abort
+    if !exists('g:intero_buffer_id')
+        echomsg 'Intero not running.'
+        return
+    endif
+    call jobsend(g:intero_job_id, "\<C-u>")
 endfunction
 
 function! intero#repl#uses() abort


### PR DESCRIPTION
This should fix #66 by sending `C-u` to the REPL before running the reload function.

I wasn't sure if we want this as a separate `clear` function, or just call the `call jobsend(g:intero_job_id, "\<C-u>")` inside the `reload` function. Should be very easy to change if needed anyhow!